### PR TITLE
`role` instead of `global`

### DIFF
--- a/1cplt-rascal/pom.xml
+++ b/1cplt-rascal/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.rascalmpl</groupId>
   <artifactId>1cplt-rascal</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/1cplt-rascal/src/main/rascal/icplt/core/chor/IDE.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/chor/IDE.rsc
@@ -136,5 +136,5 @@ str toLabel(str _: /^<name:[@0-9A-Za-z.]+>$/)
 /*                                 `foreach`                                  */
 /* -------------------------------------------------------------------------- */
 
-str toLabel(str _: /^\(foreach\<[@0-9A-Za-z]+\> <name:[0-9A-Za-z]+>, [0-9]*\).elem$/)
+str toLabel(str _: /^\(foreach\<[@0-9A-Za-z\ :;{}]+\> <name:[0-9A-Za-z]+>, [0-9]*\).elem$/)
     = "<name>." ;

--- a/1cplt-rascal/src/main/rascal/icplt/core/chor/semantics/Static.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/chor/semantics/Static.rsc
@@ -119,10 +119,10 @@ default list[Message] check(CHOR_TYPE t, CHOR_CONTEXT c, CHOR_EXPRESSION e)
 @autoName test bool _0a19c055995cf36ad5bde9e7547908a1() = check(chor("@alice"), c2, esc("\\echo", [val(5)])) == [] ;
 @autoName test bool _44234ec8e442e7dac41801387b78060a() = check(chor("@alice"), c2, esc("\\echo", [val(5), val(6)])) != [] ;
 @autoName test bool _2a7f7dd68699e172eee8d85fba06c8ac() = check(chor("@alice"), c2, esc("\\echo", [app("-", [val(5), val(true)])])) != [] ;
-@autoName test bool _e5e674e602e78e3146374b0b806132ab() = check(chor("@alice"), c2, esc("\\ping", [val(5)])) == [] ;
-@autoName test bool _ead3c0e86cb782db7840b62b7784d393() = check(chor("@alice"), c2, esc("\\ping", [val("foo")])) != [] ;
-@autoName test bool _7aa8c920c2750a3200898112aeebc292() = check(chor("@alice"), c2, esc("\\ping", [val(5), val(6)])) != [] ;
-@autoName test bool _f6d5284dd0e3fe8cc6c0c7a94451bbdd() = check(chor("@alice"), c2, esc("\\ping", [app("-", [val(5), val(true)])])) != [] ;
+@autoName test bool _9f2bd5c63a9b0ee07a096eae0ecbb510() = check(chor("@alice"), c2, esc("\\ping", [val(5)])) == [] ;
+@autoName test bool _1710bdcc1f14f0aab10f2d0fd5f04a24() = check(chor("@alice"), c2, esc("\\ping", [val("foo")])) != [] ;
+@autoName test bool _5722ef7335e56f62eca85c1e40ccb39e() = check(chor("@alice"), c2, esc("\\ping", [val(5), val(6)])) != [] ;
+@autoName test bool _4ed1913a8252f77f81959c6546b96100() = check(chor("@alice"), c2, esc("\\ping", [app("-", [val(5), val(true)])])) != [] ;
 @autoName test bool _0203f092fc2795454a0dcb7df167754f() = check(chor("@alice"), c2, CHOR_EXPRESSION::var("f")) == [] ;
 @autoName test bool _e35809cf4ede85aac05fe7f13fc77103() = check(chor("@alice"), c2, CHOR_EXPRESSION::var("g")) != [] ;
 @autoName test bool _409437fdc8091251a897af424d17d55e() = check(chor("@alice"), c2, CHOR_EXPRESSION::var("h")) != [] ;

--- a/1cplt-rascal/src/main/rascal/icplt/core/chor/syntax/Abstract.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/chor/syntax/Abstract.rsc
@@ -91,11 +91,11 @@ CHOR_VARIABLE toAbstract(x: (ChorVariable) _)
 
 CHOR_EXPRESSION toAbstract(e: (ChorExpression) `foreach\<<DataType tData>\> <DataVariable xData> in <DataExpression eData> do <ChorExpression e1>`)
     = seq(
-        asgn(xDataColl, toAbstract(eData)),
+        asgn(xDataColl, toAbstract(eData)) [src = eData.src],
         loop(
             app("!=", [app("length", [var(xDataColl)]), val(0)]),
             seq(
-                asgn("<xDataElem>", app("??", [app("aaccess", [var(xDataColl), val(0)]), defaultOf(toAbstract(tData))])),
+                asgn("<xDataElem>", app("??", [app("aaccess", [var(xDataColl), val(0)]), defaultOf(toAbstract(tData)) [src = xData.src]])),
                 seq(
                     substVar("<xData>", xDataElem, toAbstract(e1)),
                     asgn(xDataColl, app("slice", [var(xDataColl), val(1)]))
@@ -109,13 +109,13 @@ CHOR_EXPRESSION toAbstract(e: (ChorExpression) `foreach\<<DataType tData>\> <Dat
 map[DATA_VARIABLE, DATA_TYPE] toGammaForeach(CHOR_EXPRESSION e) {
     map[DATA_VARIABLE, DATA_TYPE] gamma = ();
 
-    for (/asgn(/^\(foreach\<<s1:[@0-9A-Za-z]+>\> <s2:[0-9A-Za-z]+>, <offset:[0-9]*>\).coll$/, _) := e) {
+    for (/asgn(/^\(foreach\<<s1:[@0-9A-Za-z :;{}]+>\> <s2:[0-9A-Za-z]+>, <offset:[0-9]*>\).coll$/, _) := e) {
         DATA_TYPE tData = toAbstract(parse(#DataType, s1));
         DATA_VARIABLE xData = s2;
 
         gamma += (
-            "(foreach\<<toStr(tData)>\> <xData>, <offset>).coll": array(tData),
-            "(foreach\<<toStr(tData)>\> <xData>, <offset>).elem": tData
+            "(foreach\<<s1>\> <xData>, <offset>).coll": array(tData),
+            "(foreach\<<s1>\> <xData>, <offset>).elem": tData
         );
     }
 

--- a/1cplt-rascal/src/main/rascal/icplt/core/chor/syntax/Abstract.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/chor/syntax/Abstract.rsc
@@ -137,3 +137,5 @@ DATA_EXPRESSION defaultOf(DATA_TYPE _: string())
     = val("") ;
 DATA_EXPRESSION defaultOf(DATA_TYPE _: array(t1))
     = val([]) ;
+DATA_EXPRESSION defaultOf(DATA_TYPE _: object(entries))
+    = val((k: v | k <- entries, val(v) := defaultOf(entries[k]))) ;

--- a/1cplt-rascal/src/main/rascal/icplt/core/prog/semantics/Static.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/prog/semantics/Static.rsc
@@ -61,7 +61,7 @@ list[Message] analyze(PROG_CONTEXT c, PROG_EXPRESSION e) {
     messages += [warning("Duplicate name", glob.rSrc)  | glob <- duplicateGlobs];
     messages += [warning("Duplicate name", proc.rkSrc) | proc <- duplicateProcs];
 
-    // Check well-typedness of globals
+    // Check well-typedness of roles
     c = toProgContext(e);
     CHOR_CONTEXT cChor = CHOR_CONTEXT::context(c.gammas, c.deltas);
     messages += [*check(chor(r), cChor, eChor)| /glob(r, _, [*_, proced(_, eChor), *_]) := e];

--- a/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Abstract.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Abstract.rsc
@@ -25,9 +25,9 @@ PROG_EXPRESSION toAbstract(e: (ProgExpression) `<Directive _>`)
 PROG_EXPRESSION toAbstract(e: (ProgExpression) `<ProgExpression e1> <ProgExpression e2>`)
     = seq(toAbstract(e1), toAbstract(e2)) [src = e.src] ;
 
-@autoName test bool _e5df19b9a8ef06e5a14f8c62b349a21e() = compare(toAbstract(parse(#ProgExpression, "role @alice()")), glob("@alice", [], [proced("main", skip())])) ;
+@autoName test bool _188f7be011594b42859e2b2e53354518() = compare(toAbstract(parse(#ProgExpression, "role @alice()")), glob("@alice", [], [proced("main", skip())])) ;
 @autoName test bool _26025a27fd6df3a230c1cd61e9cc3800() = compare(toAbstract(parse(#ProgExpression, "process @alice[5]()")), proc(<"@alice", 5>, [], CHOR_EXPRESSION::var("main"))) ;
-@autoName test bool _af20a478ad168d6730d9583fde96e576() = compare(toAbstract(parse(#ProgExpression, "role @alice() role @bob() role @carol()")), seq(seq(glob("@alice", [], [proced("main", skip())]), glob("@bob", [], [proced("main", skip())])), glob("@carol", [], [proced("main", skip())]))) ;
+@autoName test bool _0d58009016b73b8d3b74369c80d1e905() = compare(toAbstract(parse(#ProgExpression, "role @alice() role @bob() role @carol()")), seq(seq(glob("@alice", [], [proced("main", skip())]), glob("@bob", [], [proced("main", skip())])), glob("@carol", [], [proced("main", skip())]))) ;
 
 /*
  * Expressions: Roles
@@ -38,10 +38,10 @@ PROG_EXPRESSION toAbstract(e: (RoleDefinition) `role <Role r>(<{FormalParameter 
 PROG_EXPRESSION toAbstract(e: (RoleDefinition) `role <Role r>(<{FormalParameter ","}* formals>) { <Procedure* proceds> }`)
     = glob(toAbstract(r), [*toAbstract(formal) | formal <- formals], addMain([toAbstract(proced) | proced <- proceds])) [src = e.src] [rSrc = r.src] ;
 
-@autoName test bool _405a086da7e84e7640471ee04ac5cbc0() = compare(toAbstract(parse(#RoleDefinition, "role @alice()")), glob("@alice", [], [proced("main", skip())])) ;
-@autoName test bool _177f520b67f8cc8f8b49200dc8857fec() = compare(toAbstract(parse(#RoleDefinition, "role @alice(x: number, y: boolean)")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", skip())])) ;
-@autoName test bool _9b17befb2929497bab28a08c00a3be3a() = compare(toAbstract(parse(#RoleDefinition, "role @alice() { main: assign assign: x := 5 }")), glob("@alice", [], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
-@autoName test bool _fcf06dd688192cfd7e95bdfefbec3a45() = compare(toAbstract(parse(#RoleDefinition, "role @alice(x: number, y: boolean) { main: assign assign: x := 5 }")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
+@autoName test bool _a0d8241b9ec7d41f1cb9372786241862() = compare(toAbstract(parse(#RoleDefinition, "role @alice()")), glob("@alice", [], [proced("main", skip())])) ;
+@autoName test bool _32baf377e4e5acf9cea004c1bca94205() = compare(toAbstract(parse(#RoleDefinition, "role @alice(x: number, y: boolean)")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", skip())])) ;
+@autoName test bool _66dc133fceb5edbca164a2fda680c25c() = compare(toAbstract(parse(#RoleDefinition, "role @alice() { main: assign assign: x := 5 }")), glob("@alice", [], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
+@autoName test bool _1eda478459ef733f6f70f667e06632b6() = compare(toAbstract(parse(#RoleDefinition, "role @alice(x: number, y: boolean) { main: assign assign: x := 5 }")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
 
 private list[PROCEDURE] addMain(list[PROCEDURE] proceds)
     = proceds + ((/proced("main", _) := proceds) ? [] : [proced("main", skip())]) ;

--- a/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Abstract.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Abstract.rsc
@@ -16,7 +16,7 @@ data PROG_EXPRESSION(loc src = |unknown:///|)
     | seq(PROG_EXPRESSION e1, PROG_EXPRESSION e2)
     ;
 
-PROG_EXPRESSION toAbstract(e: (ProgExpression) `<Global _>`)
+PROG_EXPRESSION toAbstract(e: (ProgExpression) `<RoleDefinition _>`)
     = toAbstract(e.args[0]) ;
 PROG_EXPRESSION toAbstract(e: (ProgExpression) `<Process _>`)
     = toAbstract(e.args[0]) ;
@@ -25,23 +25,23 @@ PROG_EXPRESSION toAbstract(e: (ProgExpression) `<Directive _>`)
 PROG_EXPRESSION toAbstract(e: (ProgExpression) `<ProgExpression e1> <ProgExpression e2>`)
     = seq(toAbstract(e1), toAbstract(e2)) [src = e.src] ;
 
-@autoName test bool _e5df19b9a8ef06e5a14f8c62b349a21e() = compare(toAbstract(parse(#ProgExpression, "global @alice()")), glob("@alice", [], [proced("main", skip())])) ;
+@autoName test bool _e5df19b9a8ef06e5a14f8c62b349a21e() = compare(toAbstract(parse(#ProgExpression, "role @alice()")), glob("@alice", [], [proced("main", skip())])) ;
 @autoName test bool _26025a27fd6df3a230c1cd61e9cc3800() = compare(toAbstract(parse(#ProgExpression, "process @alice[5]()")), proc(<"@alice", 5>, [], CHOR_EXPRESSION::var("main"))) ;
-@autoName test bool _af20a478ad168d6730d9583fde96e576() = compare(toAbstract(parse(#ProgExpression, "global @alice() global @bob() global @carol()")), seq(seq(glob("@alice", [], [proced("main", skip())]), glob("@bob", [], [proced("main", skip())])), glob("@carol", [], [proced("main", skip())]))) ;
+@autoName test bool _af20a478ad168d6730d9583fde96e576() = compare(toAbstract(parse(#ProgExpression, "role @alice() role @bob() role @carol()")), seq(seq(glob("@alice", [], [proced("main", skip())]), glob("@bob", [], [proced("main", skip())])), glob("@carol", [], [proced("main", skip())]))) ;
 
 /*
- * Expressions: Globals
+ * Expressions: Roles
  */
 
-PROG_EXPRESSION toAbstract(e: (Global) `global <Role r>(<{FormalParameter ","}* formals>)`)
+PROG_EXPRESSION toAbstract(e: (RoleDefinition) `role <Role r>(<{FormalParameter ","}* formals>)`)
     = glob(toAbstract(r), [*toAbstract(formal) | formal <- formals], addMain([])) [src = e.src] [rSrc = r.src] ;
-PROG_EXPRESSION toAbstract(e: (Global) `global <Role r>(<{FormalParameter ","}* formals>) { <Procedure* proceds> }`)
+PROG_EXPRESSION toAbstract(e: (RoleDefinition) `role <Role r>(<{FormalParameter ","}* formals>) { <Procedure* proceds> }`)
     = glob(toAbstract(r), [*toAbstract(formal) | formal <- formals], addMain([toAbstract(proced) | proced <- proceds])) [src = e.src] [rSrc = r.src] ;
 
-@autoName test bool _405a086da7e84e7640471ee04ac5cbc0() = compare(toAbstract(parse(#Global, "global @alice()")), glob("@alice", [], [proced("main", skip())])) ;
-@autoName test bool _177f520b67f8cc8f8b49200dc8857fec() = compare(toAbstract(parse(#Global, "global @alice(x: number, y: boolean)")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", skip())])) ;
-@autoName test bool _9b17befb2929497bab28a08c00a3be3a() = compare(toAbstract(parse(#Global, "global @alice() { main: assign assign: x := 5 }")), glob("@alice", [], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
-@autoName test bool _fcf06dd688192cfd7e95bdfefbec3a45() = compare(toAbstract(parse(#Global, "global @alice(x: number, y: boolean) { main: assign assign: x := 5 }")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
+@autoName test bool _405a086da7e84e7640471ee04ac5cbc0() = compare(toAbstract(parse(#RoleDefinition, "role @alice()")), glob("@alice", [], [proced("main", skip())])) ;
+@autoName test bool _177f520b67f8cc8f8b49200dc8857fec() = compare(toAbstract(parse(#RoleDefinition, "role @alice(x: number, y: boolean)")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", skip())])) ;
+@autoName test bool _9b17befb2929497bab28a08c00a3be3a() = compare(toAbstract(parse(#RoleDefinition, "role @alice() { main: assign assign: x := 5 }")), glob("@alice", [], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
+@autoName test bool _fcf06dd688192cfd7e95bdfefbec3a45() = compare(toAbstract(parse(#RoleDefinition, "role @alice(x: number, y: boolean) { main: assign assign: x := 5 }")), glob("@alice", [formal("x", number()), formal("y", boolean())], [proced("main", CHOR_EXPRESSION::var("assign")), proced("assign", asgn("x", val(5)))])) ;
 
 private list[PROCEDURE] addMain(list[PROCEDURE] proceds)
     = proceds + ((/proced("main", _) := proceds) ? [] : [proced("main", skip())]) ;

--- a/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Abstract.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Abstract.rsc
@@ -18,7 +18,7 @@ data PROG_EXPRESSION(loc src = |unknown:///|)
 
 PROG_EXPRESSION toAbstract(e: (ProgExpression) `<RoleDefinition _>`)
     = toAbstract(e.args[0]) ;
-PROG_EXPRESSION toAbstract(e: (ProgExpression) `<Process _>`)
+PROG_EXPRESSION toAbstract(e: (ProgExpression) `<ProcessDefinition _>`)
     = toAbstract(e.args[0]) ;
 PROG_EXPRESSION toAbstract(e: (ProgExpression) `<Directive _>`)
     = empty() [src = e.src] ;
@@ -30,7 +30,7 @@ PROG_EXPRESSION toAbstract(e: (ProgExpression) `<ProgExpression e1> <ProgExpress
 @autoName test bool _0d58009016b73b8d3b74369c80d1e905() = compare(toAbstract(parse(#ProgExpression, "role @alice() role @bob() role @carol()")), seq(seq(glob("@alice", [], [proced("main", skip())]), glob("@bob", [], [proced("main", skip())])), glob("@carol", [], [proced("main", skip())]))) ;
 
 /*
- * Expressions: Roles
+ * Expressions: Role Definitions
  */
 
 PROG_EXPRESSION toAbstract(e: (RoleDefinition) `role <Role r>(<{FormalParameter ","}* formals>)`)
@@ -47,20 +47,20 @@ private list[PROCEDURE] addMain(list[PROCEDURE] proceds)
     = proceds + ((/proced("main", _) := proceds) ? [] : [proced("main", skip())]) ;
 
 /*
- * Expressions: Processes
+ * Expressions: Process Definitions
  */
 
-PROG_EXPRESSION toAbstract(e: (Process) `process <Pid rk>(<{ActualParameter ","}* actuals>)`)
+PROG_EXPRESSION toAbstract(e: (ProcessDefinition) `process <Pid rk>(<{ActualParameter ","}* actuals>)`)
     = proc(toAbstract(rk), [toAbstract(actual) | actual <- actuals], CHOR_EXPRESSION::var("main")) [src = e.src] [rkSrc = rk.src] ;
-PROG_EXPRESSION toAbstract(e: (Process) `process <Pid rk>(<{ActualParameter ","}* actuals>) |\> <ChorExpression eChor>`)
+PROG_EXPRESSION toAbstract(e: (ProcessDefinition) `process <Pid rk>(<{ActualParameter ","}* actuals>) |\> <ChorExpression eChor>`)
     = proc(toAbstract(rk), [toAbstract(actual) | actual <- actuals], toAbstract(eChor)) [src = e.src] [rkSrc = rk.src] ;
 
-@autoName test bool _b0afc7b971277fd5521d555a292513ef() = compare(toAbstract(parse(#Process, "process @alice[5]()")), proc(<"@alice", 5>, [], CHOR_EXPRESSION::var("main"))) ;
-@autoName test bool _02bf104e8a391d355faf8c3e7031e6f9() = compare(toAbstract(parse(#Process, "process @alice[5](5, 6)")), proc(<"@alice", 5>, [actual(val(5)), actual(val(6))], CHOR_EXPRESSION::var("main"))) ;
-@autoName test bool _7759626afa3f2ce5ba0f2685b5f93b09() = compare(toAbstract(parse(#Process, "process @bob(5, 6)")), proc(<"@bob", 0>, [actual(val(5)), actual(val(6))], CHOR_EXPRESSION::var("main"))) ;
-@autoName test bool _ddddd996bb74644b1c2c5ca689a90aef() = compare(toAbstract(parse(#Process, "process @alice[5]() |\> n := 5")), proc(<"@alice", 5>, [], asgn("n", val(5)))) ;
-@autoName test bool _2fa9e77b4fa65948677285b69057c4f4() = compare(toAbstract(parse(#Process, "process @alice[5](5, 6) |\> n := 5")), proc(<"@alice", 5>, [actual(val(5)), actual(val(6))], asgn("n", val(5)))) ;
-@autoName test bool _82c9ab2c0f73d191da1272716f625339() = compare(toAbstract(parse(#Process, "process @bob(5, 6) |\> n := 5")), proc(<"@bob", 0>, [actual(val(5)), actual(val(6))], asgn("n", val(5)))) ;
+@autoName test bool _b0afc7b971277fd5521d555a292513ef() = compare(toAbstract(parse(#ProcessDefinition, "process @alice[5]()")), proc(<"@alice", 5>, [], CHOR_EXPRESSION::var("main"))) ;
+@autoName test bool _02bf104e8a391d355faf8c3e7031e6f9() = compare(toAbstract(parse(#ProcessDefinition, "process @alice[5](5, 6)")), proc(<"@alice", 5>, [actual(val(5)), actual(val(6))], CHOR_EXPRESSION::var("main"))) ;
+@autoName test bool _7759626afa3f2ce5ba0f2685b5f93b09() = compare(toAbstract(parse(#ProcessDefinition, "process @bob(5, 6)")), proc(<"@bob", 0>, [actual(val(5)), actual(val(6))], CHOR_EXPRESSION::var("main"))) ;
+@autoName test bool _ddddd996bb74644b1c2c5ca689a90aef() = compare(toAbstract(parse(#ProcessDefinition, "process @alice[5]() |\> n := 5")), proc(<"@alice", 5>, [], asgn("n", val(5)))) ;
+@autoName test bool _2fa9e77b4fa65948677285b69057c4f4() = compare(toAbstract(parse(#ProcessDefinition, "process @alice[5](5, 6) |\> n := 5")), proc(<"@alice", 5>, [actual(val(5)), actual(val(6))], asgn("n", val(5)))) ;
+@autoName test bool _82c9ab2c0f73d191da1272716f625339() = compare(toAbstract(parse(#ProcessDefinition, "process @bob(5, 6) |\> n := 5")), proc(<"@bob", 0>, [actual(val(5)), actual(val(6))], asgn("n", val(5)))) ;
 
 /*
  * Procedures

--- a/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Concrete.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Concrete.rsc
@@ -6,15 +6,15 @@ extend icplt::core::\util::\syntax::Concrete;
 start syntax Prog = ProgExpression ;
 
 syntax ProgExpression
-    = Global
+    = RoleDefinition
     | Process
     | Directive
     > left ProgExpression ProgExpression
     ;
 
-syntax Global
-    = "global" Role "(" {FormalParameter ","}* ")"
-    | "global" Role "(" {FormalParameter ","}* ")" "{" Procedure* "}"
+syntax RoleDefinition
+    = "role" Role "(" {FormalParameter ","}* ")"
+    | "role" Role "(" {FormalParameter ","}* ")" "{" Procedure* "}"
     ;
 
 syntax Procedure = ChorVariable ":" ChorExpression ;
@@ -31,6 +31,6 @@ syntax Directive = @category="decorator" [#] (Alpha (Alnum | [_])*) !>> [0-9 A-Z
 
 keyword ProgKeyword =
     | "process"
-    | "global"
+    | "role"
     | "self"
     ;

--- a/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Concrete.rsc
+++ b/1cplt-rascal/src/main/rascal/icplt/core/prog/syntax/Concrete.rsc
@@ -7,7 +7,7 @@ start syntax Prog = ProgExpression ;
 
 syntax ProgExpression
     = RoleDefinition
-    | Process
+    | ProcessDefinition
     | Directive
     > left ProgExpression ProgExpression
     ;
@@ -19,7 +19,7 @@ syntax RoleDefinition
 
 syntax Procedure = ChorVariable ":" ChorExpression ;
 
-syntax Process
+syntax ProcessDefinition
     = "process" Pid "(" {ActualParameter ","}* ")"
     | "process" Pid "(" {ActualParameter ","}* ")" "|\>" ChorExpression
     ;

--- a/1cplt-rascal/src/main/rascal/icplt/examples/Adder.1cp
+++ b/1cplt-rascal/src/main/rascal/icplt/examples/Adder.1cp
@@ -1,4 +1,4 @@
-global @client(input: number[], sum, n: number)
+role @client(input: number[], sum, n: number)
 {
   main:
     sum := 0 ;
@@ -18,7 +18,7 @@ global @client(input: number[], sum, n: number)
     }
 }
 
-global @server(req: {n1: number; n2: number; c: @client}, resp: number)
+role @server(req: {n1: number; n2: number; c: @client}, resp: number)
 
 process @client[5]([5, 6, 7, 8], 0, 0)
 process @client[6]([1, 2, 3], 0, 0)

--- a/1cplt-rascal/src/main/rascal/icplt/examples/AnyBuyer.1cp
+++ b/1cplt-rascal/src/main/rascal/icplt/examples/AnyBuyer.1cp
@@ -1,4 +1,4 @@
-global @buyer1(x, f: number, neigh: @buyeri)
+role @buyer1(x, f: number, neigh: @buyeri)
 {
   main:
     "foo" -> @seller.title |> {
@@ -12,7 +12,7 @@ global @buyer1(x, f: number, neigh: @buyeri)
     }
 }
 
-global @buyeri(
+role @buyeri(
   x, y, f: number,
   last: boolean,
   neigh: @buyeri)
@@ -30,7 +30,7 @@ global @buyeri(
     }
 }
 
-global @seller(
+role @seller(
   title: string,
   result: boolean,
   neighs: @buyeri[])

--- a/1cplt-rascal/src/main/rascal/icplt/examples/ChangRoberts.1cp
+++ b/1cplt-rascal/src/main/rascal/icplt/examples/ChangRoberts.1cp
@@ -1,4 +1,4 @@
-global @node(neigh: @node, x, y: number, z: boolean)
+role @node(neigh: @node, x, y: number, z: boolean)
 {
   main:
     x -> neigh.y |> forward

--- a/1cplt-rascal/src/main/rascal/icplt/examples/Echo.1cp
+++ b/1cplt-rascal/src/main/rascal/icplt/examples/Echo.1cp
@@ -1,4 +1,4 @@
-global @node(
+role @node(
   init: boolean,
   neighs, senders: @node[],
   parent, sender:  @node)

--- a/1cplt-rascal/src/main/rascal/icplt/examples/HelloWorld.1cp
+++ b/1cplt-rascal/src/main/rascal/icplt/examples/HelloWorld.1cp
@@ -3,7 +3,7 @@ role @alice(i, n: number)
   main:
     \save ;
     i := 0 ;
-    while 
+    while
       i < n
     do {
       inc ;

--- a/1cplt-rascal/src/main/rascal/icplt/examples/HelloWorld.1cp
+++ b/1cplt-rascal/src/main/rascal/icplt/examples/HelloWorld.1cp
@@ -1,4 +1,4 @@
-global @alice(i, n: number)
+role @alice(i, n: number)
 {
   main:
     \save ;
@@ -18,7 +18,7 @@ global @alice(i, n: number)
     i := i + 1
 }
 
-global @bob(s: string)
+role @bob(s: string)
 
 process @alice(0, 5)
 process @bob("")

--- a/1cplt-rascal/src/main/rascal/icplt/examples/MOutOfN.1cp
+++ b/1cplt-rascal/src/main/rascal/icplt/examples/MOutOfN.1cp
@@ -1,4 +1,4 @@
-global @prod(ok: boolean)
+role @prod(ok: boolean)
 {
   main:
     self -> @cons.p |>
@@ -11,7 +11,7 @@ global @prod(ok: boolean)
         false -> p.ok
 }
 
-global @cons(p: @prod, ps: @prod[], m: number)
+role @cons(p: @prod, ps: @prod[], m: number)
 
 process @prod[1](false)
 process @prod[2](false)

--- a/1cplt-rascal/src/test/rascal/icplt/scratch/prog/Scratch.1cp-prog
+++ b/1cplt-rascal/src/test/rascal/icplt/scratch/prog/Scratch.1cp-prog
@@ -1,4 +1,4 @@
-global @alice(i: number, foo: number, b: boolean, xyz: number[], s: string)
+role @alice(i: number, foo: number, b: boolean, xyz: number[], s: string)
 {
   main:
     i := [5, 6][0] ?? 7 ;
@@ -26,7 +26,7 @@ global @alice(i: number, foo: number, b: boolean, xyz: number[], s: string)
         s := s + x + y + " "
 }
 
-global @bob(i: number, bar: number, a: @alice)
+role @bob(i: number, bar: number, a: @alice)
 
 process @alice[5](6, 8, true, [], "")
 process @bob(8, 9, @alice[5])


### PR DESCRIPTION
This PR renames the `global` keyword to `role`. It also fixes a few minor issues with: (a) `foreach`; (b) type inference/checking of object values. As this PR makes breaking changes, the version number is changed accordingly.